### PR TITLE
Adiciona as libs celery e kombu no Pipfile

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,8 @@ name = "pypi"
 importlib-metadata = "==4.13.0"
 flask = "==2.3.3"
 hijiki = "*"
+kombu = "*"
+celery = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "fc8737ec83d6934be1225cf4e980b73d2174875af5d9c86d201efcdcd6f3970b"
+            "sha256": "a254729e2b26c8997deb4750df3e4a63b6593386832f1f7463f1f5013a322cd5"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,22 @@
         ]
     },
     "default": {
+        "amqp": {
+            "hashes": [
+                "sha256:2c1b13fecc0893e946c65cbd5f36427861cffa4ea2201d8f6fca22e2a373b5e2",
+                "sha256:6f0956d2c23d8fa6e7691934d8c3930eadb44972cbbd1a7ae3a520f735d43359"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==5.1.1"
+        },
+        "billiard": {
+            "hashes": [
+                "sha256:0f50d6be051c6b2b75bfbc8bfd85af195c5739c281d3f5b86a5640c65563614a",
+                "sha256:1ad2eeae8e28053d729ba3373d34d9d6e210f6e4d8bf0a9c64f92bd053f1edf5"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==4.1.0"
+        },
         "blinker": {
             "hashes": [
                 "sha256:152090d27c1c5c722ee7e48504b02d76502811ce02e1523553b4cf8c8b3d3a8d",
@@ -24,6 +40,15 @@
             "markers": "python_version >= '3.7'",
             "version": "==1.6.3"
         },
+        "celery": {
+            "hashes": [
+                "sha256:1e6ed40af72695464ce98ca2c201ad0ef8fd192246f6c9eac8bba343b980ad34",
+                "sha256:9023df6a8962da79eb30c0c84d5f4863d9793a466354cc931d7f72423996de28"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==5.3.4"
+        },
         "click": {
             "hashes": [
                 "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28",
@@ -31,6 +56,29 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==8.1.7"
+        },
+        "click-didyoumean": {
+            "hashes": [
+                "sha256:a0713dc7a1de3f06bc0df5a9567ad19ead2d3d5689b434768a6145bff77c0667",
+                "sha256:f184f0d851d96b6d29297354ed981b7dd71df7ff500d82fa6d11f0856bee8035"
+            ],
+            "markers": "python_full_version >= '3.6.2' and python_full_version < '4.0.0'",
+            "version": "==0.3.0"
+        },
+        "click-plugins": {
+            "hashes": [
+                "sha256:46ab999744a9d831159c3411bb0c79346d94a444df9a3a3742e9ed63645f264b",
+                "sha256:5d262006d3222f5057fd81e1623d4443e41dcda5dc815c06b442aa3c02889fc8"
+            ],
+            "version": "==1.1.1"
+        },
+        "click-repl": {
+            "hashes": [
+                "sha256:17849c23dba3d667247dc4defe1757fff98694e90fe37474f3feebb69ced26a9",
+                "sha256:fb7e06deb8da8de86180a33a9da97ac316751c094c6899382da7feeeeb51b812"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==0.3.0"
         },
         "flask": {
             "hashes": [
@@ -43,11 +91,11 @@
         },
         "hijiki": {
             "hashes": [
-                "sha256:a7b1b2fcbd25f5d85df43878f491195f15ae1cbf4f496f25c139a0259355c823",
-                "sha256:e2bac28fddd89f5fe66c1e0ea2bf9cb49910a824dd5bdf971f9ef1dcd7e66889"
+                "sha256:0019f3268e051ebc81802a73db2b134493035c89fb825ddcbbf82edd11e2bdfb",
+                "sha256:e19faddab667aa39912c6c2f155e5452fb9d1a84ff520ff538e5fca252561efa"
             ],
             "index": "pypi",
-            "version": "==1.0.51"
+            "version": "==1.0.52"
         },
         "importlib-metadata": {
             "hashes": [
@@ -73,6 +121,15 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==3.1.2"
+        },
+        "kombu": {
+            "hashes": [
+                "sha256:0ba213f630a2cb2772728aef56ac6883dc3a2f13435e10048f6e97d48506dbbd",
+                "sha256:b753c9cfc9b1e976e637a7cbc1a65d446a22e45546cd996ea28f932082b7dc9e"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==5.3.2"
         },
         "markupsafe": {
             "hashes": [
@@ -139,6 +196,53 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==2.1.3"
+        },
+        "prompt-toolkit": {
+            "hashes": [
+                "sha256:04505ade687dc26dc4284b1ad19a83be2f2afe83e7a828ace0c72f3a1df72aac",
+                "sha256:9dffbe1d8acf91e3de75f3b544e4842382fc06c6babe903ac9acb74dc6e08d88"
+            ],
+            "markers": "python_full_version >= '3.7.0'",
+            "version": "==3.0.39"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
+                "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.8.2"
+        },
+        "six": {
+            "hashes": [
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.16.0"
+        },
+        "tzdata": {
+            "hashes": [
+                "sha256:11ef1e08e54acb0d4f95bdb1be05da659673de4acbd21bf9c69e94cc5e907a3a",
+                "sha256:7e65763eef3120314099b6939b5546db7adce1e7d6f2e179e3df563c70511eda"
+            ],
+            "markers": "python_version >= '2'",
+            "version": "==2023.3"
+        },
+        "vine": {
+            "hashes": [
+                "sha256:4c9dceab6f76ed92105027c49c823800dd33cacce13bdedc5b914e3514b7fb30",
+                "sha256:7d3b1624a953da82ef63462013bbd271d3eb75751489f9807598e8f340bd637e"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==5.0.0"
+        },
+        "wcwidth": {
+            "hashes": [
+                "sha256:9a929bd8380f6cd9571a968a9c8f4353ca58d7cd812a4822bba831f8d685b223",
+                "sha256:a675d1a4a2d24ef67096a04b85b02deeecd8e226f57b5e3a72dbb9ed99d27da8"
+            ],
+            "version": "==0.2.9"
         },
         "werkzeug": {
             "hashes": [


### PR DESCRIPTION
Estamos usando as libs `celery` e `kombu` na poc para iniciar o broker (`application/broker/celery_configs.py`) e worker (`worker.py`) sem o `hijiki`, porém elas não estão especificadas no Pipfile, o que acaba causando erros na hora de rodar a aplicação:

```bash
celery-rabbit-poc_1  | Traceback (most recent call last):
celery-rabbit-poc_1  |   File "/app/worker.py", line 3, in <module>
celery-rabbit-poc_1  |     from kombu.mixins import ConsumerMixin, logger
celery-rabbit-poc_1  | ModuleNotFoundError: No module named 'kombu'
celery-rabbit-poc_1  | Usage: flask run [OPTIONS]
celery-rabbit-poc_1  | Try 'flask run --help' for help.
celery-rabbit-poc_1  | 
celery-rabbit-poc_1  | Error: While importing 'app', an ImportError was raised:
celery-rabbit-poc_1  | 
celery-rabbit-poc_1  | Traceback (most recent call last):
celery-rabbit-poc_1  |   File "/usr/local/lib/python3.11/site-packages/flask/cli.py", line 219, in locate_app
celery-rabbit-poc_1  |     __import__(module_name)
celery-rabbit-poc_1  |   File "/app/app.py", line 2, in <module>
celery-rabbit-poc_1  |     from hijiki.publisher.Publisher import Publisher
celery-rabbit-poc_1  | 
celery-rabbitmq-poc-fork_celery-rabbit-poc_1 exited with code 2
```

Este PR adiciona as libs que estão faltando no Pipfile.