### PR TITLE
Adiciona health check no serviço do RabbitMQ na configuração do Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,11 @@ services:
             - ~/.docker-conf/rabbitmq/log/:/var/log/rabbitmq
         networks:
             - rabbitmq_go_net
+        healthcheck:
+            test: ["CMD", "rabbitmqctl", "status"]
+            interval: 5s
+            timeout: 10s
+            retries: 10
     celery-rabbit-poc:
         environment:
             BROKER_SERVER: "rabbitmq"
@@ -21,7 +26,8 @@ services:
         ports:
             - "5000:5000"
         depends_on:
-            - "rabbitmq"
+            rabbitmq:
+                condition: service_healthy
         links:
             - rabbitmq
         networks:


### PR DESCRIPTION
Neste PR adicionei um health check no serviço `rabbitmq` na configuração do Docker Compose para garantir que o serviço esteja pronto para receber conexões quando o serviço `celery-rabbit-poc` começar.

Caso contrário, o `celery-rabbit-poc` pode tentar se conectar com o RabbitMQ, antes que o RabbitMQ esteja completamente iniciado e pronto, causando o seguinte problema:

```bash
celery-rabbit-poc_1  | Traceback (most recent call last):
celery-rabbit-poc_1  |   File "/usr/local/bin/flask", line 8, in <module>
celery-rabbit-poc_1  |     sys.exit(main())
celery-rabbit-poc_1  |              ^^^^^^
celery-rabbit-poc_1  |   File "/usr/local/lib/python3.11/site-packages/flask/cli.py", line 1064, in main
celery-rabbit-poc_1  |     cli.main()
celery-rabbit-poc_1  |   File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1078, in main
celery-rabbit-poc_1  |     rv = self.invoke(ctx)
celery-rabbit-poc_1  |          ^^^^^^^^^^^^^^^^
celery-rabbit-poc_1  |   File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
celery-rabbit-poc_1  |     return _process_result(sub_ctx.command.invoke(sub_ctx))
celery-rabbit-poc_1  |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
celery-rabbit-poc_1  |   File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
celery-rabbit-poc_1  |     return ctx.invoke(self.callback, **ctx.params)
celery-rabbit-poc_1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
celery-rabbit-poc_1  |   File "/usr/local/lib/python3.11/site-packages/click/core.py", line 783, in invoke
celery-rabbit-poc_1  |     return __callback(*args, **kwargs)
celery-rabbit-poc_1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
celery-rabbit-poc_1  |   File "/usr/local/lib/python3.11/site-packages/click/decorators.py", line 92, in new_func
celery-rabbit-poc_1  |     return ctx.invoke(f, obj, *args, **kwargs)
celery-rabbit-poc_1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
celery-rabbit-poc_1  |   File "/usr/local/lib/python3.11/site-packages/click/core.py", line 783, in invoke
celery-rabbit-poc_1  |     return __callback(*args, **kwargs)
celery-rabbit-poc_1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
celery-rabbit-poc_1  |   File "/usr/local/lib/python3.11/site-packages/flask/cli.py", line 912, in run_command
celery-rabbit-poc_1  |     raise e from None
celery-rabbit-poc_1  |   File "/usr/local/lib/python3.11/site-packages/flask/cli.py", line 898, in run_command
celery-rabbit-poc_1  |     app = info.load_app()
celery-rabbit-poc_1  |           ^^^^^^^^^^^^^^^
celery-rabbit-poc_1  |   File "/usr/local/lib/python3.11/site-packages/flask/cli.py", line 309, in load_app
celery-rabbit-poc_1  |     app = locate_app(import_name, name)
celery-rabbit-poc_1  |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
celery-rabbit-poc_1  |   File "/usr/local/lib/python3.11/site-packages/flask/cli.py", line 219, in locate_app
celery-rabbit-poc_1  |     __import__(module_name)
celery-rabbit-poc_1  |   File "/app/app.py", line 9, in <module>
celery-rabbit-poc_1  |     broker = GT_Broker('client')
celery-rabbit-poc_1  |              ^^^^^^^^^^^^^^^^^^^
celery-rabbit-poc_1  |   File "/app/application/broker/celery_configs.py", line 19, in __init__
celery-rabbit-poc_1  |     self.bind_queues()
celery-rabbit-poc_1  |   File "/app/application/broker/celery_configs.py", line 15, in bind_queues
celery-rabbit-poc_1  |     dead_letter_queue.bind(self.celery_broker.broker_connection()).declare()
celery-rabbit-poc_1  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
celery-rabbit-poc_1  |   File "/usr/local/lib/python3.11/site-packages/kombu/entity.py", line 601, in bind
celery-rabbit-poc_1  |     bound = super().bind(channel)
celery-rabbit-poc_1  |             ^^^^^^^^^^^^^^^^^^^^^
celery-rabbit-poc_1  |   File "/usr/local/lib/python3.11/site-packages/kombu/abstract.py", line 93, in bind
celery-rabbit-poc_1  |     return copy(self).maybe_bind(channel)
celery-rabbit-poc_1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
celery-rabbit-poc_1  |   File "/usr/local/lib/python3.11/site-packages/kombu/abstract.py", line 100, in maybe_bind
celery-rabbit-poc_1  |     self._channel = maybe_channel(channel)
celery-rabbit-poc_1  |                     ^^^^^^^^^^^^^^^^^^^^^^
celery-rabbit-poc_1  |   File "/usr/local/lib/python3.11/site-packages/kombu/connection.py", line 1110, in maybe_channel
celery-rabbit-poc_1  |     return channel.default_channel
celery-rabbit-poc_1  |            ^^^^^^^^^^^^^^^^^^^^^^^
celery-rabbit-poc_1  |   File "/usr/local/lib/python3.11/site-packages/kombu/connection.py", line 953, in default_channel
celery-rabbit-poc_1  |     self._ensure_connection(**conn_opts)
celery-rabbit-poc_1  |   File "/usr/local/lib/python3.11/site-packages/kombu/connection.py", line 458, in _ensure_connection
celery-rabbit-poc_1  |     with ctx():
celery-rabbit-poc_1  |   File "/usr/local/lib/python3.11/contextlib.py", line 155, in __exit__
celery-rabbit-poc_1  |     self.gen.throw(typ, value, traceback)
celery-rabbit-poc_1  |   File "/usr/local/lib/python3.11/site-packages/kombu/connection.py", line 476, in _reraise_as_library_errors
celery-rabbit-poc_1  |     raise ConnectionError(str(exc)) from exc
celery-rabbit-poc_1  | kombu.exceptions.OperationalError: [Errno 111] Connection refused
celery-rabbitmq-poc-fork_celery-rabbit-poc_1 exited with code 1
```
