### PR TITLE
Substitui BaseException por Exception na task de exemplo

### DIFF
--- a/application/tasks/tasks.py
+++ b/application/tasks/tasks.py
@@ -1,4 +1,4 @@
-class MyException(BaseException):
+class MyException(Exception):
     pass
 def hello_task(who='world'):
     print(f'Received {who}')


### PR DESCRIPTION
O worker só faz o requeue caso uma instância de `Exception` (ou algum herdeiro de `Exception`) seja lançado.

```python
    def process_task(self, body, message):
        fun = body['fun']
        args = body['args']
        kwargs = body['kwargs']
        logger.info('Got task: %s', reprcall(fun.__name__, args, kwargs))
        try:
            fun(*args, **kwargs)
            message.ack()
        except Exception as exc:
            message.requeue()
```

Porem essa task está jogando uma `BaseException` que está mais alto na hierarquia do que a `Exception`, fazendo com que o worker não considere ela para requeue e crashando a aplicação.

<img width="1100" alt="image" src="https://github.com/asengardeon/celery-rabbitmq-poc/assets/27960416/d3725439-fa24-403e-b6d9-d5a9a17af537">

---

Neste PR, substituo `BaseException` por `Exception`, fazendo o worker tratar corretamente o erro e reagendar a tarefa.

<img width="1124" alt="image" src="https://github.com/asengardeon/celery-rabbitmq-poc/assets/27960416/1277a458-e40e-4be5-a87d-bc3b9a17046e">
